### PR TITLE
Fix league/commonmark constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "symfony/phpunit-bridge": "^4.1.8",
         "erusev/parsedown": "^1.7",
-        "league/commonmark": "*",
+        "league/commonmark": "^0.4 || ^1.0",
         "league/html-to-markdown": "^4.8",
         "michelf/php-markdown": "^1.8"
     },


### PR DESCRIPTION
The `League\CommonMark\CommonMarkConverter` class was introduced in version 0.4.0.  (It used a different namespace in previous versions.)  I have promised to not break backward-compatibility in any future 1.x release per https://github.com/thephpleague/commonmark#versioning so this constraint should be safe.