### PR TITLE
Bump Twig constraint to only include namespaced versions (fixes #2)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "twig/twig": "^1.0 || ^2.0"
+        "twig/twig": "^1.34 || ^2.4"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.1.8",


### PR DESCRIPTION
Possible solution for #2 